### PR TITLE
Adjust UUID formatting for static data tables

### DIFF
--- a/src/db_extractor_full.py
+++ b/src/db_extractor_full.py
@@ -104,7 +104,7 @@ def db_extractor():
                 table_data = cursor.fetchall()
                 column_names = [desc[0] for desc in cursor.description]
                 data_with_col_names = [{column_names[i]: row[i] for i in range(len(column_names))} for row in table_data]
-                json_data = json.dumps(data_with_col_names, cls=UUIDEncoder)
+                json_data = json.dumps(data_with_col_names, cls=UUIDEncoder, default=str)
             # If we have created_at but no updated_at, we dump based only on created_at
             elif found_updated_at == False and found_created_at == True:
                 last_run_time = json_parameter_value['data']['lastRunTime']


### PR DESCRIPTION
Related [Slack Thread](https://ustcdp3.slack.com/archives/C018TH07PRR/p1680036733766969) 

In the case where a table has neither an updated_at column nor a created_at column, the call to json.dumps() was missing a default arg, so the UUIDs are not returned as `obj.hex` which was interfering with joins to these tables. 