### PR TITLE
HDT-9310

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,3 +4,4 @@ six>=1.5
 asn1crypto==1.5.1
 boto3>=1.35.51
 boto3-stubs
+orjson==3.10.7


### PR DESCRIPTION
[MMHDT-9130](https://jira.csde.caci.com/browse/MMHDT-9130)

Lambda was timing out. Too much data, extraction took too long. Memory not an issue. Encoding and uploading was the bottleneck. Not sure how much more we can optimize this thing.

- Uploading takes <1 second
- Db fetching takes roughly 100ms
- Hard limit of 6 processors

Permanent fix:

One of two. 1 is pretty, 2 is realistic

1. Have a parent lambda. Parent lambda checks size of tables, then spins up additional lambdas to handle the load. Like load balancing / kubernetes fanciness,
  a. Would be SUPER fast. Could scale up so many processors and just power through the tables
2. Move it to an ECS container as a single sole provider still.
  a. Cranks up the timeout to as long as we want it to. Minimal changes, does the job

